### PR TITLE
Make RSpec inclusion it's own thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ If using with Cucumber, add the following to your `support/env.rb`.
 require 'capybara/ui/cucumber'
 ```
 
+If you are using with RSpec, add the following to your `spec_helper.rb` or
+`support/env.rb` file.
+
+```ruby
+require 'capybara/ui/rspec'
+```
+
 ## Contributing
 We welcome pull requests. Please make sure tests accompany any PRs. Email Adam at ags@mojotech.com if you have questions.
 

--- a/lib/capybara/ui/checkpoint.rb
+++ b/lib/capybara/ui/checkpoint.rb
@@ -14,11 +14,6 @@ module Capybara
 
       self.rescuable_errors = [StandardError]
 
-      if defined?(RSpec)
-        require 'rspec/expectations'
-        self.rescuable_errors << RSpec::Expectations::ExpectationNotMetError
-      end
-
       class Timer
         class Frozen < StandardError; end
 

--- a/lib/capybara/ui/rspec.rb
+++ b/lib/capybara/ui/rspec.rb
@@ -1,0 +1,3 @@
+require 'rspec/expectations'
+
+Capybara::UI::Checkpoint.rescuable_errors << RSpec::Expectations::ExpectationNotMetError


### PR DESCRIPTION
Previously, depending on order of libary loading,
RSpec constant might not have been defined at the
time the Checkpoint class was evaluated.  As such,
the RSpec expectations were not added to the list of
`Checkpoint.rescuable_errors` even though they were
defined at runtime.

This makes rspec inclusion a more 'first-class' citizen
and explicitly requires users to include RSpec support
if they want it.