### PR TITLE
Travis CI fix, Headless Chrome, Rails 5 test app, Ruby versions for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=9028ccc64391f650aacd79af2eb66ba6d19bc5e96d3af2916c126a9809c4ddce
+addons:
+  chrome: stable
+services:
+  - xvfb
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 language: ruby
 rvm:
   - 2.2.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 cache: bundler
 script:
   - bundle exec rspec spec

--- a/capybara-ui.gemspec
+++ b/capybara-ui.gemspec
@@ -22,12 +22,14 @@ Gem::Specification.new do |s|
   s.add_dependency 'capybara', '~> 3.0'
 
   s.add_development_dependency 'rspec-given', '~> 3.5.0'
-  s.add_development_dependency 'capybara-webkit', '~> 1.7.0'
-  s.add_development_dependency 'poltergeist', '~> 1.17.0'
+  s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'webdrivers'
+  s.add_development_dependency 'cuprite'
   s.add_development_dependency 'cucumber', '~> 1.3.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
+  s.add_development_dependency 'puma'
   s.add_development_dependency 'sinatra'
-  s.add_development_dependency 'rails', '~> 4.2.9'
+  s.add_development_dependency 'rails', '~> 5.2.0'
   s.add_development_dependency 'simplecov'
 end

--- a/features/support/10_app.rb
+++ b/features/support/10_app.rb
@@ -7,8 +7,9 @@ class CapybaraUIApp < Rails::Application
 
   secret = '39a988a1711e621dbc7718d4c89f5e3f'
   config.session_store :cookie_store, :key => secret
-  config.secret_token = secret
   config.secret_key_base = secret
+
+  config.action_controller.perform_caching = false
 
   log_file = File.new(File.join(config.root, 'log', 'test.log'), 'w+')
   config.logger = Logger.new(log_file)
@@ -36,12 +37,12 @@ module WebApp
 
     TestController.class_eval do
       define_method name do
-        render :text => html
+        render html: html.html_safe
       end
     end
 
     CapybaraUIApp.routes.draw do
-      get path => "test##{name}", :as => name
+      get path, to: "test##{name}", as: name
     end
   end
 end

--- a/features/support/30_capybara.rb
+++ b/features/support/30_capybara.rb
@@ -1,5 +1,7 @@
-require 'capybara/poltergeist'
+require 'capybara/cuprite'
+require 'webdrivers'
 
 Capybara.default_max_wait_time = 2
 Capybara.app = CapybaraUIApp
-Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.current_driver = :selenium_chrome_headless

--- a/lib/capybara/ui/matchers.rb
+++ b/lib/capybara/ui/matchers.rb
@@ -1,9 +1,9 @@
 def permitted_rspec_version?
-  actual_rspec_expectations_version >= required_rspec_expectations_version
+  defined? RSpec && actual_rspec_expectations_version >= required_rspec_expectations_version
 end
 
 def actual_rspec_expectations_version
-  Gem::Version.new(RSpec::Expectations::Version::STRING)
+  defined? RSpec && Gem::Version.new(RSpec::Expectations::Version::STRING)
 end
 
 def required_rspec_expectations_version

--- a/lib/capybara/ui/version.rb
+++ b/lib/capybara/ui/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module UI
-    VERSION = '1.0.3'
+    VERSION = '1.1.0'
   end
 end

--- a/lib/capybara/ui/widgets.rb
+++ b/lib/capybara/ui/widgets.rb
@@ -29,7 +29,7 @@ module Capybara
       def Decimal(*selector)
         Widget(selector) { |text|
           # ensure we can convert to float first
-          Float(text) && BigDecimal.new(text)
+          Float(text) && BigDecimal(text)
         }
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,17 +6,21 @@ require 'pry'
 require 'rspec/given'
 require 'sinatra/base'
 require 'capybara/rspec'
-require 'capybara/webkit'
-require 'capybara/poltergeist'
+require 'capybara/cuprite'
+require 'webdrivers'
 
 Dir["./spec/support/**/*.rb"].each { |file| require file }
 
-DRIVERS = [:webkit, :poltergeist]
+DRIVERS = [:selenium_chrome_headless]
 
 class CapybaraUIApp < Sinatra::Base; end
 Capybara.app = CapybaraUIApp
 
-Capybara.javascript_driver = :webkit
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800])
+end
+
+Capybara.javascript_driver = :cuprite
 
 module WidgetSpecDSL
   def GivenAction(body_html, path)


### PR DESCRIPTION
- Replace capybara-webkit with headless Chrome
- Update the versions of Ruby that get tested in Travis CI to most recent supported versions
- Fix(matchers): Bypass the RSpec version check if RSpec is not loaded
- Fix(Travis CI): xvfb is a service now -- manually starting xvfb no longer works

TODO/Question: I'm not certain of the purpose of the `DRIVERS` array here, so I have not removed it across the board.  I've only limited the values in the `DRIVERS` array for now.  Are any other values necessary here after switching to headless Chrome?

