### PR TITLE
Version 1.3.0 - Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - 2.5.8
   - 2.6.5
   - 2.7.2
+  - 3.0.0
 cache: bundler
 script:
   - bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 language: ruby
 rvm:
-  - 2.4.9
-  - 2.5.7
+  - 2.5.8
   - 2.6.5
+  - 2.7.2
 cache: bundler
 script:
   - bundle exec rspec spec

--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+# Version 1.3.0
+
+### Changed
+
+* Update keyword argument usage in `node_filter` to resolve deprecation warnings in Ruby 2.7 and errors in Ruby 3.0.0 (Thanks, @thomasbalsloev!)
+* Add `rexml` to the gem bundle to support Ruby 3.0.0
+
 # Version 1.2.0
 
 ### Changed

--- a/capybara-ui.gemspec
+++ b/capybara-ui.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chronic'
   s.add_dependency 'capybara', '~> 3.0'
+  s.add_dependency 'rexml'
 
   s.add_development_dependency 'rspec-given', '>= 3.8'
   s.add_development_dependency 'selenium-webdriver'

--- a/capybara-ui.gemspec
+++ b/capybara-ui.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chronic'
   s.add_dependency 'capybara', '~> 3.0'
 
-  s.add_development_dependency 'rspec-given', '~> 3.5.0'
+  s.add_development_dependency 'rspec-given', '>= 3.8'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'cuprite'

--- a/capybara-ui.gemspec
+++ b/capybara-ui.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'cuprite'
-  s.add_development_dependency 'cucumber', '~> 2.0'
+  s.add_development_dependency 'cucumber', '>= 5.3'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
   s.add_development_dependency 'puma'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,6 @@
+require_relative './00_codeclimate'
+require_relative './10_app'
+require_relative './20_widget'
+require_relative './30_capybara'
+require_relative './99_constants'
+require_relative './expectations'

--- a/lib/capybara/ui/version.rb
+++ b/lib/capybara/ui/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module UI
-    VERSION = '1.2.0'
+    VERSION = '1.3.0'
   end
 end


### PR DESCRIPTION
* Update development dependencies `cucumber` and `rspec-given` to resolve deprecation warnings and erroneously failing tests
* Add `rexml` to the gem bundle to support Ruby 3.0.0
* Test the latest supported Ruby versions in Travis CI
* Bump to version 1.3.0